### PR TITLE
Allow BrowserWindow option overrides

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const { EventEmitter2 } = require('eventemitter2');
 class ElectronPreferences extends EventEmitter2 {
 
     constructor(options = {}) {
-        
+
         super();
 
         _.defaultsDeep(options, {
@@ -158,7 +158,7 @@ class ElectronPreferences extends EventEmitter2 {
             return;
         }
 
-        this.prefsWindow = new BrowserWindow({
+        let browserWindowOpts = {
             'title': 'Preferences',
             'width': 800,
             'maxWidth': 800,
@@ -170,7 +170,13 @@ class ElectronPreferences extends EventEmitter2 {
             'backgroundColor': '#E7E7E7',
             'show': true,
             'webPreferences': this.options.webPreferences
-        });
+        };
+
+        if (this.options.browserWindowOverrides) {
+            browserWindowOpts = Object.assign(browserWindowOpts, this.options.browserWindowOverrides);
+        }
+
+        this.prefsWindow = new BrowserWindow(browserWindowOpts);
 
         this.prefsWindow.loadURL(url.format({
             'pathname': path.join(__dirname, 'build/index.html'),

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "example": "cd example && electron main.js",
+    "prepare": "npm run build",
     "build": "grunt build"
   },
   "author": "Tim Ambler <tkambler@gmail.com>",


### PR DESCRIPTION
Added optional property to the opts parameter of the ElectronPreferences constructor called `browserWindowOverrides` that will override specific BrowserWindow opts.

This will allow the consumer of the ElectronPreferences library to have more control over the BrowserWindow behavior from electron and mitigate against breaking electron framework version changes.