### PR TITLE
BrowserWindow Menu inject opts and lic

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2019 Tim Ambler <tkambler@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -178,6 +178,12 @@ class ElectronPreferences extends EventEmitter2 {
 
         this.prefsWindow = new BrowserWindow(browserWindowOpts);
 
+        if (this.options.menuBar) {
+            this.prefsWindow.setMenu(this.options.menuBar);
+        } else {
+            this.prefsWindow.removeMenu();
+        }
+
         this.prefsWindow.loadURL(url.format({
             'pathname': path.join(__dirname, 'build/index.html'),
             'protocol': 'file:',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "grunt build"
   },
   "author": "Tim Ambler <tkambler@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
prefs can now accept a menu injection; otherwise `win.removeMenu()` is used https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#winsetmenunull

MIT License text added with license text attributing copyrights to Tim
