### PR TITLE
fix#73: Fix accidentally overwriting webprefs 

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,14 +188,15 @@ class ElectronPreferences extends EventEmitter2 {
             contextIsolation: true,
             preload: path.join(__dirname, './preload.js')
         }
+
+        if (this.options.browserWindowOverrides) {
+            browserWindowOpts = Object.assign(browserWindowOpts, this.options.browserWindowOverrides);
+        }
+
         if (browserWindowOpts.webPreferences) {
             browserWindowOpts.webPreferences = Object.assign(defaultWebPreferences, browserWindowOpts.webPreferences)
         } else {
             browserWindowOpts.webPreferences = defaultWebPreferences;
-        }
-
-        if (this.options.browserWindowOverrides) {
-            browserWindowOpts = Object.assign(browserWindowOpts, this.options.browserWindowOverrides);
         }
 
         this.prefsWindow = new BrowserWindow(browserWindowOpts);


### PR DESCRIPTION
If `preferences.browserOverrides.webPreferences` was included, it overwrote the `defaultWebPreferences` since `Object.assign()` only does a shallow clone. This would mean the preload script wouldn't be set if `webPreferences` were included this way, and we see the error #73 .

This should fix that issue.