### PR TITLE
fix#58: remove fs-extra; write files atomically

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
   },
   "dependencies": {
     "eventemitter2": "^5.0.1",
-    "fs-extra": "^5.0.0",
+    "load-json-file": "^6.2.0",
     "lodash": "^4.17.21",
     "react-color": "^2.14.1",
-    "react-modal": "^3.13.1"
+    "react-modal": "^3.13.1",
+    "write-json-file": "^4.3.0"
   }
 }


### PR DESCRIPTION
Fix #58 
This uses atomic writes instead of `fs-extra.writeJSON()` to prevent errors during writes; Removes `fs-extra`, adds helper libraries by sindresorhus.

