### PR TITLE
fix #93: return instance of prefsWindow

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,6 +333,8 @@ class ElectronPreferences extends EventEmitter2 {
 
 		});
 
+		return this.prefsWindow
+
 	}
 
 }


### PR DESCRIPTION
Return the preferencesWindow from `preferences.show()`