### PR TITLE
Feature/124/debug preference

### DIFF
--- a/example/preferences.js
+++ b/example/preferences.js
@@ -19,8 +19,9 @@ const preferences = new ElectronPreferences({
 		},
 		// ...
 	},
+	debug: true,
 	webPreferences: {
-		devTools: true,
+		webSecurity: true
 	},
 	browserWindowOverrides: {
 		title: 'My Electron Preferences',

--- a/example/preferences.js
+++ b/example/preferences.js
@@ -19,7 +19,7 @@ const preferences = new ElectronPreferences({
 		},
 		// ...
 	},
-	debug: true,
+	debug: false, //true will open the dev tools
 	webPreferences: {
 		webSecurity: true
 	},

--- a/index.js
+++ b/index.js
@@ -246,6 +246,7 @@ class ElectronPreferences extends EventEmitter2 {
 
 		const unOverridableWebPreferences = {
 			contextIsolation: true,
+			devTools: this.options.debug ? true : undefined
 		}
 
 		// User provider `browserWindow`, we load those
@@ -275,6 +276,12 @@ class ElectronPreferences extends EventEmitter2 {
 		if (this.prefsWindow) {
 
 			this.prefsWindow.focus();
+
+			if (this.options.debug) {
+
+				this.prefsWindow.webContents.openDevTools();
+
+			}
 
 			return this.prefsWindow;
 
@@ -343,6 +350,14 @@ class ElectronPreferences extends EventEmitter2 {
 			this.prefsWindow = null;
 
 		});
+
+
+
+        if (this.options.debug) {
+
+            this.prefsWindow.webContents.openDevTools();
+
+        }
 
 		return this.prefsWindow;
 


### PR DESCRIPTION
Closes #124 

To easily open the dev tools add the `{ debug: true }` option in the preferences object