### PR TITLE
Reset to defaults functionality and fix defaults object being overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Freezing UI when clicking a button type in the preferences window (#161)
+- Defaults could be changed by passing around the defaults object (#150)
 
 ### Added
 - Added `allowOnlyModifier` property to the accelerator input to allow shortcuts like `Alt` or `Shift`
 - type 'number' instead of having to declare type 'text' with 'inputType = number' (#168)
 - Maximum and minimum list size via `min` and `max` list properties (#164)
+- `resetToDefaults` endpoint to the preferences object which removes any non-default properties and set all default properties to their default values (#97)
 
 ### Changed
 - bump dependencies to their latest version

--- a/example/index.html
+++ b/example/index.html
@@ -9,6 +9,7 @@
         <div class="buttons">
             <button class="bt">Click here to launch the preferences window</button>
             <button class="bt">Close preference window if opened</button>
+            <button class="bt">Reset to defaults</button>
         </div>
         <pre class="preferences"></pre>
         <script src="renderer.js"></script>

--- a/example/preload.js
+++ b/example/preload.js
@@ -23,7 +23,9 @@ contextBridge.exposeInMainWorld('api', {
 
 		onPreferencesChangedHandler = handler;
 
-	},
+	}, 
+	getDefaults: () => ipcRenderer.sendSync('getDefaults'),
+	resetToDefaults: () => ipcRenderer.send('resetToDefaults'),
 });
 
 ipcRenderer.on('preferencesUpdated', (e, preferences) => {

--- a/example/renderer.js
+++ b/example/renderer.js
@@ -3,6 +3,7 @@
 
 const bt = document.querySelectorAll('.bt')[0];
 const bt2 = document.querySelectorAll('.bt')[1];
+const bt3 = document.querySelectorAll('.bt')[2];
 const prefsElement = document.querySelectorAll('.preferences')[0];
 prefsElement.innerHTML = JSON.stringify(api.getPreferences(), null, 4);
 
@@ -15,6 +16,12 @@ bt.addEventListener('click', () => {
 bt2.addEventListener('click', () => {
 
 	api.closePreferences();
+
+});
+
+bt3.addEventListener('click', () => {
+				
+	api.resetToDefaults();
 
 });
 

--- a/index.js
+++ b/index.js
@@ -161,6 +161,12 @@ class ElectronPreferences extends EventEmitter2 {
 
 		});
 
+		ipcMain.on('resetToDefaults', event => {
+
+			this.resetToDefaults();
+
+		});
+
 		if (_.isFunction(options.afterLoad)) {
 
 			options.afterLoad(this);
@@ -183,7 +189,7 @@ class ElectronPreferences extends EventEmitter2 {
 
 	get defaults() {
 
-		return this.options.defaults || {};
+		return _.cloneDeep(this.options.defaults || {});
 
 	}
 
@@ -392,6 +398,14 @@ class ElectronPreferences extends EventEmitter2 {
 
 		this.prefsWindow.close();
 
+	}
+
+	resetToDefaults() {
+
+					this._preferences = this.defaults;
+					
+					this.save();
+					this.broadcast();
 	}
 
 }


### PR DESCRIPTION
add resetToDefaults endpoint in preferences object. Fixes #150 
adapt example to include a resetToDefaults button. Fixes #97 