### PR TITLE
fix duplicate declaration of `getPreferences` and `getSections`

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -12,8 +12,6 @@ contextBridge.exposeInMainWorld('api', {
 	getPreferences: () => ipcRenderer.sendSync('getPreferences'),
 	getDefaults: () => ipcRenderer.sendSync('getDefaults'),
 	getConfig: () => ipcRenderer.sendSync('getConfig'),
-	getPreferences: () => ipcRenderer.sendSync('getPreferences'),
-	getSections: () => ipcRenderer.sendSync('getSections'),
 	setPreferences: preferences => ipcRenderer.send('setPreferences', preferences),
 	showOpenDialog: dialogOptions => ipcRenderer.sendSync('showOpenDialog', dialogOptions),
 	sendButtonClick: channel => ipcRenderer.send('sendButtonClick', channel),


### PR DESCRIPTION
fix duplicate declaration of `getPreferences` and `getSections` within the contextBridge's preload.js

fixes #210 